### PR TITLE
Allow custom identity driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -330,6 +330,21 @@ Enable Federated keystone
           - wsgi
           - shib2
 
+Use a custom identity driver with custom options
+
+.. code-block:: yaml
+
+    keystone:
+      server:
+        identity:
+          driver = custom_driver
+        custom_sections:
+          custom_driver:
+            my_option = my_value
+            other_option = other_value
+
+
+
 Keystone client
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -338,11 +338,16 @@ Use a custom identity driver with custom options
       server:
         identity:
           driver = custom_driver
-        custom_sections:
-          custom_driver:
-            my_option: my_value
-            other_option: other_value
-
+        k2k:
+          auth_url: 'https://keystone.example.com/v2.0'
+          read_user: 'example_user'
+          read_pass: 'password'
+          read_tenant_id: 'admin'
+          identity_driver: 'sql'
+          id_prefix: 'k2k:'
+          domain: 'default'
+          caching: true
+          cache_time: 600
 
 
 Keystone client

--- a/README.rst
+++ b/README.rst
@@ -336,8 +336,7 @@ Use a custom identity driver with custom options
 
     keystone:
       server:
-        identity:
-          driver = custom_driver
+        backend: k2k
         k2k:
           auth_url: 'https://keystone.example.com/v2.0'
           read_user: 'example_user'

--- a/README.rst
+++ b/README.rst
@@ -340,8 +340,8 @@ Use a custom identity driver with custom options
           driver = custom_driver
         custom_sections:
           custom_driver:
-            my_option = my_value
-            other_option = other_value
+            my_option: my_value
+            other_option: other_value
 
 
 

--- a/keystone/files/_k2k.conf
+++ b/keystone/files/_k2k.conf
@@ -1,0 +1,46 @@
+
+[k2k]
+
+#
+# Specific driver configuration for identity backend k2k
+# (Authentication against other keystone backend as fallback)
+#
+
+# Authentication URL of keystone to authenticate against (v2.0 only)
+# (string value)
+#auth_url = https://keystone.example.com/v2.0
+auth_url = {{ k2k.auth_url }}
+
+# User that is able to read users (string value)
+#read_user = admin
+read_user = {{ k2k.read_user }}
+
+# Password for readonly user (string value)
+#read_pass = password
+read_pass = {{ k2k.read_pass }}
+
+# Tenant id to be used to read (string value)
+#read_tenant_id = admin
+read_tenant_id = {{ k2k.read_tenant_id }}
+
+# Keystone identity driver to use before k2k authentication (string value)
+#identity_driver = sql
+identity_driver = {{ k2k.get('identity_driver', 'sql') }}
+
+# UserId prefix to use for assignment mappings etc (string value)
+#id_prefix = k2k:
+id_prefix = {{ k2k.get('id_prefix', 'k2k:') }}
+
+# This value will be set in the User object after authentication (string value)
+#domain = default
+domain = {{ k2k.get('domain', 'default') }}
+
+# Toggle for k2k caching. This has no effect unless global caching is enabled.
+# (boolean value)
+#caching = true
+caching = {{ k2k.get('caching', 'true')|lower }}
+
+# Time to cache identity data (in seconds). This has no effect unless global and
+# identity caching are enabled. (integer value)
+#cache_time = 600
+cache_time = {{ k2k.get('cache_time', 600) }}

--- a/keystone/files/mitaka/keystone.conf.Debian
+++ b/keystone/files/mitaka/keystone.conf.Debian
@@ -951,7 +951,7 @@ domain_config_dir = /etc/keystone/domains
 {%- if server.get('backend', 'sql') == 'ldap' %}
 driver = ldap
 {%- else %}
-driver = server.get('identity', {}).get('backend', 'sql')
+driver = {{ server.get('identity', {}).get('backend', 'sql') }}
 {%- endif %}
 
 # Toggle for identity caching. This has no effect unless global caching is

--- a/keystone/files/mitaka/keystone.conf.Debian
+++ b/keystone/files/mitaka/keystone.conf.Debian
@@ -948,11 +948,7 @@ domain_config_dir = /etc/keystone/domains
 # Entrypoint for the identity backend driver in the keystone.identity
 # namespace. Supplied drivers are ldap and sql. (string value)
 #driver = sql
-{%- if server.get('backend', 'sql') == 'ldap' %}
-driver = ldap
-{%- else %}
-driver = {{ server.get('identity', {}).get('backend', 'sql') }}
-{%- endif %}
+driver = {{ server.get('backend', 'sql') }}
 
 # Toggle for identity caching. This has no effect unless global caching is
 # enabled. (boolean value)
@@ -971,6 +967,10 @@ driver = {{ server.get('identity', {}).get('backend', 'sql') }}
 # (integer value)
 #list_limit = <None>
 
+{%- if server.get("backend", "sql") == "k2k" and server.k2k is defined %}
+{%- set k2k = server.k2k %}
+{% include "keystone/files/_k2k.conf" %}
+{%- endif %}
 
 [identity_mapping]
 
@@ -2193,52 +2193,3 @@ driver = memcache_pool
 
 [extra_headers]
 Distribution = Ubuntu
-
-{% if server.get('k2k') %}
-[k2k]
-
-#
-# Specific driver configuration for identity backend k2k
-# (Authentication against other keystone backend as fallback)
-#
-
-# Authentication URL of keystone to authenticate against (v2.0 only)
-# (string value)
-#auth_url = https://keystone.example.com/v2.0
-auth_url = {{ server.k2k.get('auth_url')}}
-
-# User that is able to read users (string value)
-#read_user = admin
-read_user = {{ server.k2k.get('read_user')}}
-
-# Password for readonly user (string value)
-#read_pass = password
-read_pass = {{ server.k2k.get('read_pass')}}
-
-# Tenant id to be used to read (string value)
-#read_tenant_id = admin
-read_tenant_id = {{ server.k2k.get('read_tenant_id')}}
-
-# Keystone identity driver to use before k2k authentication (string value)
-#identity_driver = sql
-identity_driver = {{ server.k2k.get('identity_driver', 'sql')}}
-
-# UserId prefix to use for assignment mappings etc (string value)
-#id_prefix = k2k:
-id_prefix = {{ server.k2k.get('id_prefix', 'k2k:')}}
-
-# This value will be set in the User object after authentication (string value)
-#domain = default
-domain = {{ server.k2k.get('domain', 'default')}}
-
-# Toggle for k2k caching. This has no effect unless global caching is enabled.
-# (boolean value)
-#caching = true
-caching = {{ server.k2k.get('caching', 'true')}}
-
-# Time to cache identity data (in seconds). This has no effect unless global and 
-# identity caching are enabled. (integer value)
-#cache_time = 600
-cache_time = {{ server.k2k.get('cache_time', 600)}}
-
-{% endif %}

--- a/keystone/files/mitaka/keystone.conf.Debian
+++ b/keystone/files/mitaka/keystone.conf.Debian
@@ -2194,10 +2194,51 @@ driver = memcache_pool
 [extra_headers]
 Distribution = Ubuntu
 
-{% for section in server.get('custom_sections', {}) %}
-[{{ section }}]
-{% for key, value in server['custom_sections'][section].items() %}
-{{ key }} = {{ value }}
-{% endfor %}
+{% if server.get('k2k') %}
+[k2k]
 
-{% endfor %}
+#
+# Specific driver configuration for identity backend k2k
+# (Authentication against other keystone backend as fallback)
+#
+
+# Authentication URL of keystone to authenticate against (v2.0 only)
+# (string value)
+#auth_url = https://keystone.example.com/v2.0
+auth_url = {{ server.k2k.get('auth_url')}}
+
+# User that is able to read users (string value)
+#read_user = admin
+read_user = {{ server.k2k.get('read_user')}}
+
+# Password for readonly user (string value)
+#read_pass = password
+read_pass = {{ server.k2k.get('read_pass')}}
+
+# Tenant id to be used to read (string value)
+#read_tenant_id = admin
+read_tenant_id = {{ server.k2k.get('read_tenant_id')}}
+
+# Keystone identity driver to use before k2k authentication (string value)
+#identity_driver = sql
+identity_driver = {{ server.k2k.get('identity_driver', 'sql')}}
+
+# UserId prefix to use for assignment mappings etc (string value)
+#id_prefix = k2k:
+id_prefix = {{ server.k2k.get('id_prefix', 'k2k:')}}
+
+# This value will be set in the User object after authentication (string value)
+#domain = default
+domain = {{ server.k2k.get('domain', 'default')}}
+
+# Toggle for k2k caching. This has no effect unless global caching is enabled.
+# (boolean value)
+#caching = true
+caching = {{ server.k2k.get('caching', 'true')}}
+
+# Time to cache identity data (in seconds). This has no effect unless global and 
+# identity caching are enabled. (integer value)
+#cache_time = 600
+cache_time = {{ server.k2k.get('cache_time', 600)}}
+
+{% endif %}

--- a/keystone/files/mitaka/keystone.conf.Debian
+++ b/keystone/files/mitaka/keystone.conf.Debian
@@ -951,7 +951,7 @@ domain_config_dir = /etc/keystone/domains
 {%- if server.get('backend', 'sql') == 'ldap' %}
 driver = ldap
 {%- else %}
-driver = sql
+driver = server.get('identity', {}).get('backend', 'sql')
 {%- endif %}
 
 # Toggle for identity caching. This has no effect unless global caching is
@@ -2193,3 +2193,11 @@ driver = memcache_pool
 
 [extra_headers]
 Distribution = Ubuntu
+
+{% for section in server.get('custom_sections', {}) %}
+[{{ section }}]
+{% for key, value in server['custom_sections'][section].items() %}
+{{ key }} = {{ value }}
+{% endfor %}
+
+{% endfor %}


### PR DESCRIPTION
(which falls back to sql) and allow custom configuration by defining keystone.server.custom_sections 