### PR TITLE
Remove not needed configs

### DIFF
--- a/keystone/server.sls
+++ b/keystone/server.sls
@@ -7,13 +7,9 @@ keystone_packages:
 
 {%- if server.service_name in ['apache2', 'httpd'] %}
 {%- if not grains.get('noservices', False) %}
-/etc/apache2/sites-available/wsgi-keystone.conf:
+purge_not_needed_configs:
   file.absent:
-    - watch_in:
-      - service: keystone_service
-
-/etc/apache2/sites-enabled/wsgi-keystone.conf:
-  file.absent:
+    - names: ['/etc/apache2/sites-enabled/keystone.conf', '/etc/apache2/sites-enabled/wsgi-keystone.conf']
     - watch_in:
       - service: keystone_service
 {%- endif %}


### PR DESCRIPTION
Sometimes additional apache conf files
may come with keystone package. So adding additional purge step.