### PR TITLE
WIP: Changes for token engine in newton and ocata

### DIFF
--- a/keystone/files/newton/keystone.conf.Debian
+++ b/keystone/files/newton/keystone.conf.Debian
@@ -2788,7 +2788,9 @@ expiration = {{ server.tokens.expiration }}
 # later validating those signatures. (string value)
 #provider = uuid
 {% if server.tokens.engine == 'fernet' %}
-provider = keystone.token.providers.fernet.Provider
+provider = fernet
+{% else %}
+provider = uuid
 {% endif %}
 
 # Entry point for the token persistence backend driver in the
@@ -2800,7 +2802,9 @@ provider = keystone.token.providers.fernet.Provider
 # you're using the `fernet` `[token] provider`, this backend will not be
 # utilized to persist tokens at all. (string value)
 #driver = sql
-driver = keystone.token.persistence.backends.memcache_pool.Token
+{% if server.tokens.engine == 'database' %}
+driver = memcache_pool
+{% endif %}
 
 # Toggle for caching token creation and validation data. This has no effect
 # unless global caching is enabled. (boolean value)

--- a/keystone/files/ocata/keystone.conf.Debian
+++ b/keystone/files/ocata/keystone.conf.Debian
@@ -2975,7 +2975,9 @@ expiration = {{ server.tokens.expiration }}
 # fernet_rotate` command). (string value)
 #provider = fernet
 {% if server.tokens.engine == 'fernet' %}
-provider = keystone.token.providers.fernet.Provider
+provider = fernet
+{% else %}
+provider = uuid
 {% endif %}
 
 # Entry point for the token persistence backend driver in the
@@ -2985,7 +2987,9 @@ provider = keystone.token.providers.fernet.Provider
 # `[database]` section. If you're using the `fernet` `[token] provider`, this
 # backend will not be utilized to persist tokens at all. (string value)
 #driver = sql
-driver = keystone.token.persistence.backends.memcache_pool.Token
+{% if server.tokens.engine == 'database' %}
+driver = sql
+{% endif %}
 
 # Toggle for caching token creation and validation data. This has no effect
 # unless global caching is enabled. (boolean value)


### PR DESCRIPTION
Marking WIP to solicit more feedback. I fee like the default engine should be 
fernet for recent releases due to the deprecation and changes in other engines
but I don't know how that would affect backwards compatibility here for users.


The default token engine changed to fernet in the newton cycle, so if
the pillar defines some other engine we should respect that. For now
this assumes that other engine is UUID tokens.

The persistence does not apply if using fernet tokens, so don't attempt
to set it.

The memcache_pool token persistence engine was entirely removed in
Ocata; the only engine still available is SQL.

These drivers are loaded through stevedore and issue warnings on ocata
if looking up by classname, so use the entrypoint instead.