### PR TITLE
Support Python 3

### DIFF
--- a/_modules/keystone_policy.py
+++ b/_modules/keystone_policy.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import sys
 
 LOG = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class OrderedDictYAMLLoader(yaml.Loader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise yaml.constructor.ConstructorError('while constructing a mapping',
                     node.start_mark, 'found unacceptable key (%s)' % exc, key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)
@@ -81,7 +82,10 @@ def rule_delete(name, path, **kwargs):
                     serialized = json.dumps(rules, indent=4)
                 else:
                     serialized = yaml.safe_dump(rules, indent=4)
-                file_handle.write(unicode(serialized))
+                if sys.version_info[0] >= 3:
+                    file_handle.write(serialized)
+                else:
+                    file_handle.write(unicode(serialized))
         except Exception as e:
             msg = "Unable to save policy file: %s" % repr(e)
             LOG.error(msg)
@@ -102,7 +106,10 @@ def rule_set(name, rule, path, **kwargs):
                     serialized = json.dumps(rules, indent=4)
                 else:
                     serialized = yaml.safe_dump(rules, indent=4)
-                file_handle.write(unicode(serialized))
+                if sys.version_info[0] >= 3:
+                    file_handle.write(serialized)
+                else:
+                    file_handle.write(unicode(serialized))
         except Exception as e:
             msg = "Unable to save policy file %s: %s" % (path, repr(e))
             LOG.error(msg)

--- a/keystone/client/project.sls
+++ b/keystone/client/project.sls
@@ -11,7 +11,7 @@ keystone_client_roles:
   - connection_tenant: {{ client.server.tenant }}
   - connection_auth_url: 'http://{{ client.server.host }}:{{ client.server.public_port }}/v2.0/'
 
-{%- for tenant_name, tenant in client.get('tenant', {}).iteritems() %}
+{%- for tenant_name, tenant in client.get('tenant', {}).items() %}
 
 keystone_tenant_{{ tenant_name }}:
   keystoneng.tenant_present:
@@ -23,7 +23,7 @@ keystone_tenant_{{ tenant_name }}:
   - require:
     - keystoneng: keystone_client_roles
 
-{%- for user_name, user in tenant.get('user', {}).iteritems() %}
+{%- for user_name, user in tenant.get('user', {}).items() %}
 
 keystone_{{ tenant_name }}_user_{{ user_name }}:
   keystoneng.user_present:

--- a/keystone/client/server.sls
+++ b/keystone/client/server.sls
@@ -1,7 +1,7 @@
 {%- from "keystone/map.jinja" import client with context %}
 {%- if client.enabled %}
 
-{%- for server_name, server in client.get('server', {}).iteritems() %}
+{%- for server_name, server in client.get('server', {}).items() %}
 
 {%- if server.admin.get('api_version', '2') == '3' %}
 {%- set version = "v3" %}
@@ -42,7 +42,7 @@ keystone_{{ server_name }}_roles:
 
 {%- endif %}
 
-{% for service_name, service in server.get('service', {}).iteritems() %}
+{% for service_name, service in server.get('service', {}).items() %}
 
 keystone_{{ server_name }}_service_{{ service_name }}:
   keystoneng.service_present:
@@ -84,7 +84,7 @@ keystone_{{ server_name }}_service_{{ service_name }}_endpoint_{{ endpoint.regio
 
 {%- endfor %}
 
-{%- for tenant_name, tenant in server.get('project', {}).iteritems() %}
+{%- for tenant_name, tenant in server.get('project', {}).items() %}
 
 keystone_{{ server_name }}_tenant_{{ tenant_name }}:
   keystoneng.tenant_present:
@@ -108,7 +108,7 @@ keystone_{{ server_name }}_tenant_{{ tenant_name }}_quota:
   novang.quota_present:
     - profile: {{ server_name }}
     - tenant_name: {{ tenant_name }}
-    {%- for quota_name, quota_value in tenant.quota.iteritems() %}
+    {%- for quota_name, quota_value in tenant.quota.items() %}
     - {{ quota_name }}: {{ quota_value }}
     {%- endfor %}
     - require:
@@ -116,7 +116,7 @@ keystone_{{ server_name }}_tenant_{{ tenant_name }}_quota:
 
 {%- endif %}
 
-{%- for user_name, user in tenant.get('user', {}).iteritems() %}
+{%- for user_name, user in tenant.get('user', {}).items() %}
 
 keystone_{{ server_name }}_tenant_{{ tenant_name }}_user_{{ user_name }}:
   keystoneng.user_present:

--- a/keystone/control.sls
+++ b/keystone/control.sls
@@ -1,5 +1,5 @@
 {%- from "keystone/map.jinja" import control with context %}
-{%- for provider_name, provider in control.get('provider', {}).iteritems() %}
+{%- for provider_name, provider in control.get('provider', {}).items() %}
 
 /root/keystonerc_{{ provider_name }}:
   file.managed:

--- a/keystone/files/kilo/keystone.conf.Debian
+++ b/keystone/files/kilo/keystone.conf.Debian
@@ -713,7 +713,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # There is nothing special about this domain, other than the fact that it must
 # exist to order to maintain support for your v2 clients. (string value)
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}

--- a/keystone/files/liberty/keystone.conf.Debian
+++ b/keystone/files/liberty/keystone.conf.Debian
@@ -873,7 +873,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # There is nothing special about this domain, other than the fact that it must
 # exist to order to maintain support for your v2 clients. (string value)
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}

--- a/keystone/files/mitaka/keystone.conf.Debian
+++ b/keystone/files/mitaka/keystone.conf.Debian
@@ -945,7 +945,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # exist to order to maintain support for your v2 clients. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -2241,9 +2241,9 @@ hash_algorithm = {{ server.hash_algorithm }}
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/files/newton/keystone.conf.Debian
+++ b/keystone/files/newton/keystone.conf.Debian
@@ -1033,7 +1033,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # reason to change this value. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -2936,9 +2936,9 @@ hash_algorithm = {{ server.hash_algorithm }}
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/files/ocata/keystone.conf.Debian
+++ b/keystone/files/ocata/keystone.conf.Debian
@@ -1132,7 +1132,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # reason to change this value. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -3119,9 +3119,9 @@ hash_algorithm = {{ server.hash_algorithm }}
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/files/ocata/keystone.conf.RedHat
+++ b/keystone/files/ocata/keystone.conf.RedHat
@@ -1101,7 +1101,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # reason to change this value. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -3070,9 +3070,9 @@ revoke_by_id = False
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/files/pike/keystone.conf.Debian
+++ b/keystone/files/pike/keystone.conf.Debian
@@ -1132,7 +1132,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # reason to change this value. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -3123,9 +3123,9 @@ hash_algorithm = {{ server.hash_algorithm }}
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/files/pike/keystone.conf.RedHat
+++ b/keystone/files/pike/keystone.conf.RedHat
@@ -1101,7 +1101,7 @@ max_active_keys={{ server.tokens.get('max_active_keys', '3') }}
 # reason to change this value. (string value)
 #default_domain_id = default
 {%- if server.get('domain', {}) %}
-{%- for name, domain in server.domain.iteritems() %}
+{%- for name, domain in server.domain.items() %}
 {%- if domain.get('default', False) %}
 default_domain_id = {{ name }}
 {%- endif %}
@@ -3072,9 +3072,9 @@ revoke_by_id = False
 Distribution = Ubuntu
 
 {% if server.extra_config is defined %}
-{%- for section, params in server.extra_config.iteritems() %}
+{%- for section, params in server.extra_config.items() %}
 [{{ section }}]
-{%- for param, value in params.iteritems() %}
+{%- for param, value in params.items() %}
 {{ param }} = {{ value }}
 {%- endfor %}
 {%- endfor %}

--- a/keystone/meta/salt.yml
+++ b/keystone/meta/salt.yml
@@ -26,7 +26,7 @@ minion:
     {%- endif %}
 
     {#- Profile based metadata #}
-    {%- for profile_name, identity in client.get('server', {}).iteritems() %}
+    {%- for profile_name, identity in client.get('server', {}).items() %}
       {%- set protocol = identity.admin.get('protocol', 'http') %}
 
       {%- if identity.admin.get('api_version', '2') == '3' %}

--- a/keystone/meta/sphinx.yml
+++ b/keystone/meta/sphinx.yml
@@ -41,7 +41,7 @@ doc:
           value: {{ server.database.user }}@{{ server.database.host }}:3306/{{ server.database.name }}
         services:
           value: |
-            {%- for service_name, service in server.get('service', {}).iteritems() %}
+            {%- for service_name, service in server.get('service', {}).items() %}
             * {{ service_name }}: {{ service.type }}, publicurl '{{ service.bind.get('public_protocol', 'http') }}://{{ service.bind.public_address }}:{{ service.bind.public_port }}{{ service.bind.public_path }}'
             {%- endfor %}
         packages:

--- a/keystone/server.sls
+++ b/keystone/server.sls
@@ -151,7 +151,7 @@ keystone_fluentd_logger_package:
   - watch_in:
     - service: {{ keystone_service }}
 
-{%- for name, rule in server.get('policy', {}).iteritems() %}
+{%- for name, rule in server.get('policy', {}).items() %}
 
 {%- if rule != None %}
 
@@ -188,7 +188,7 @@ rule_{{ name }}_absent:
     - require:
       - pkg: keystone_packages
 
-{%- for domain_name, domain in server.domain.iteritems() %}
+{%- for domain_name, domain in server.domain.items() %}
 
 /etc/keystone/domains/keystone.{{ domain_name }}.conf:
   file.managed:
@@ -382,7 +382,7 @@ keystone_admin_user:
 
 {%- endif %}
 
-{%- for service_name, service in server.get('service', {}).iteritems() %}
+{%- for service_name, service in server.get('service', {}).items() %}
 
 keystone_{{ service_name }}_service:
   keystoneng.service_present:
@@ -426,7 +426,7 @@ keystone_user_{{ service.user.name }}:
 
 {%- endfor %}
 
-{%- for tenant_name, tenant in server.get('tenant', {}).iteritems() %}
+{%- for tenant_name, tenant in server.get('tenant', {}).items() %}
 
 keystone_tenant_{{ tenant_name }}:
   keystoneng.tenant_present:
@@ -436,7 +436,7 @@ keystone_tenant_{{ tenant_name }}:
   - require:
     - keystoneng: keystone_roles
 
-{%- for user_name, user in tenant.get('user', {}).iteritems() %}
+{%- for user_name, user in tenant.get('user', {}).items() %}
 
 keystone_user_{{ user_name }}:
   keystoneng.user_present:


### PR DESCRIPTION
`json.dumps()` and `yaml.safe_dump()` return a `str` object on Python 2 and Python 3. Therefore the unicode conversion is only needed for Python 2.

Bug-Debian: https://bugs.debian.org/889929